### PR TITLE
[#102] - Configurar conexión a back desde móvil

### DIFF
--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -27,7 +27,7 @@ fastify.get("/documentation", async (request, reply) => {
   return reply.type("text/html").sendFile("/api.html");
 });
 
-fastify.listen({ port: 3000 }, (err) => {
+fastify.listen({ port: 3000, host: "0.0.0.0" }, (err) => {
   if (err) {
     fastify.log.error(err);
     process.exit(1);

--- a/front/app/_layout.tsx
+++ b/front/app/_layout.tsx
@@ -4,6 +4,12 @@ import "@/i18n";
 import { useTranslation } from "react-i18next";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
+import { client } from "@cuidamed-api/client";
+import { API_URL } from "@/config";
+
+client.setConfig({
+  baseUrl: API_URL,
+});
 
 const queryClient = new QueryClient();
 

--- a/front/config.ts
+++ b/front/config.ts
@@ -1,0 +1,21 @@
+import Constants from "expo-constants";
+import { Platform } from "react-native";
+
+// Obtener la IP local del servidor de desarrollo para conectarse al backend
+const getApiUrl = () => {
+  const manifest = Constants.expoConfig;
+  const debuggerHost = manifest?.hostUri?.split(":").shift();
+
+  // Si es un túnel de Expo (.exp.direct), no usar esa URL
+  if (debuggerHost && !debuggerHost.includes("exp.direct")) {
+    return `http://${debuggerHost}:3000`;
+  }
+
+  // Fallback para web o producción
+  return "http://localhost:3000";
+};
+
+export const API_URL = getApiUrl();
+
+console.log("API URL:", API_URL);
+console.log("Platform:", Platform.OS);


### PR DESCRIPTION
## Tarea Relacionada

Fixes #102 

## Descripción de los Cambios

Se ha configurado la app para que se pueda conectar al backend desde el móvil (todo en local).

## Notas Adicionales

### :exclamation: IMPORTANTE: Solo funciona si los dos dispositivos están en la misma red