### PR TITLE
[#67] - Implementar endpoint para consultar las tomas asociadas a un tratamiento

### DIFF
--- a/back/src/handlers.ts
+++ b/back/src/handlers.ts
@@ -6,6 +6,7 @@ import {
   getTreatmentsByUserId,
   insertIntakeToTreatment,
   deleteIntakeFromTreatment,
+  getIntakesByTreatmentId,
 } from "./repository/treatmentRepository";
 
 export const handlers: RouteHandlers = {
@@ -68,8 +69,9 @@ export const handlers: RouteHandlers = {
     await reply.status(201).send(response);
   },
   getIntakesByTreatment: async (request, reply) => {
-    Number(request.params.treatmentId);
-    reply.status(200).send([]);
+    const treatmentId = request.params.treatmentId;
+    const intakes = await getIntakesByTreatmentId(treatmentId);
+    reply.status(200).send(intakes);
   },
   deleteIntake: async (request, reply) => {
     const rowsDeleted = await deleteIntakeFromTreatment(


### PR DESCRIPTION
## Tarea Relacionada

Fixes #67

## Descripción de los Cambios

Implementar el endpoint GET `/treatments/{treatmentId}` para obtener todas las tomas (dosing schedules) asociadas a un tratamiento, incluyendo sus horarios de toma detallados.

## Cambios Realizados

### Backend (`back/src/`)

#### handlers.ts
- **getIntakesByTreatment**: Implementado handler que:
  - Recibe `treatmentId` como parámetro de ruta  - Invoca la función de repositorio para obtener los intakes
  - Retorna array de `DosingSchedule[]` con status 200

#### repository/treatmentRepository.ts
- **getIntakesByTreatmentId(treatmentId)**: Obtiene todos los intakes de un tratamiento
  - Consulta `dosing_schedule` filtrando por `treatment_id`
  - Usa `Promise.all()` para obtener los `dosingTimes` de forma paralela
  - Mapea snake_case a camelCase para la respuesta
  - Convierte fechas a formato ISO (YYYY-MM-DD)

- **getDosingTimesByScheduleId(scheduleId)**: Obtiene los horarios de una toma
  - Consulta `dosing_time` filtrando por `dosing_schedule_id`
  - Mapea propiedades: `dosing_schedule_id` → `dosingScheduleId`, `scheduled_time` → `scheduledTime`
  - Elimina segundos del horario (HH:mm:ss → HH:mm)
  - Retorna array tipado como `DosingTime[]`

## Notas Adicionales

Hay que mergear primero #65 